### PR TITLE
17 misformed attachment endpoint

### DIFF
--- a/fabric_python_helper/graph_api.py
+++ b/fabric_python_helper/graph_api.py
@@ -202,7 +202,7 @@ class Emails:
             list of tuple: A list of tuples, where each tuple contains the ID and name of an attachment.
         """
         # Constructing the URL for the Microsoft Graph API attachments endpoint
-        url = f'https://graph.microsoft.com/v1.0/{self.user_id}/messages/{message_id}/attachments'
+        url = f'https://graph.microsoft.com/v1.0/users/{self.user_id}/messages/{message_id}/attachments'
 
         # Setting up the authorization header with the access token
         headers = {

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='fabric_python_helper',
-    version='0.2.2',
+    version='0.2.3',
     packages=find_packages(),
     install_requires=[
         "msal",


### PR DESCRIPTION
Needed to change attachment end point:
- from `https://graph.microsoft.com/v1.0/{self.user_id}/messages/{message_id}/attachments`
- to `https://graph.microsoft.com/v1.0/users/{self.user_id}/messages/{message_id}/attachments`